### PR TITLE
Add CMAKE_IGNORE_PATH flag to generic `rocmcomponent` easyblock

### DIFF
--- a/easybuild/easyblocks/generic/rocmcomponent.py
+++ b/easybuild/easyblocks/generic/rocmcomponent.py
@@ -63,6 +63,7 @@ class ROCmComponent(CMakeMake):
                                                       f"{TOOLCHAIN_LLVM}, {TOOLCHAIN_HIPCC}", CUSTOM],
             'hip_platform': [HIP_PLATFORM_AMD, f"Specify HIP platform. "
                                                f"Allowed values: {HIP_PLATFORM_AMD}, {HIP_PLATFORM_NVIDIA}", CUSTOM],
+            'ignore_system_rocm': [True, "Ignore system ROCm installation", CUSTOM],
         })
         return extra_vars
 
@@ -151,4 +152,6 @@ class ROCmComponent(CMakeMake):
             # For now, pass both AMDGPU_TARGETS and GPU_TARGETS, until AMD finally drops the former for all packages.
             self.cfg['configopts'] += f'-DAMDGPU_TARGETS={self.list_to_cmake_arg(amd_gfx_list)} '
             self.cfg['configopts'] += f'-DGPU_TARGETS={self.list_to_cmake_arg(amd_gfx_list)} '
+        if self.cfg['ignore_system_rocm']:
+            self.cfg['configopts'] += "-DCMAKE_IGNORE_PREFIX_PATH=/opt/rocm "
         super().configure_step(srcdir, builddir)


### PR DESCRIPTION
While building on node with AMD MI210 GPU, easybuild often picks up `/opt/rocm` during the build which leads to multiple types of failures:

- ROCm version mismatch which results in make -j failures such as type mismatches
- Sanity checks fail because during the build it used something from `/opt/rocm`

Adding this flag helped resolved these errors for libraries such as hipBLAS, hipSOLVER, hipFFT

These builds work on a `rome` node without the flag 